### PR TITLE
[STEP11 / STEP12] 신정한 - e-commerce

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
 
 	// redis
 	implementation("org.redisson:redisson-spring-boot-starter:3.50.0")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 
@@ -70,6 +73,9 @@ dependencies {
 
 	// logger
 	implementation("io.github.oshai:kotlin-logging-jvm:7.0.12")
+
+	// Serialization
+	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.retry:spring-retry")
 
+	// redis
 	implementation("org.redisson:redisson-spring-boot-starter:3.50.0")
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
@@ -66,6 +67,9 @@ dependencies {
 
 	// Docs
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+
+	// logger
+	implementation("io.github.oshai:kotlin-logging-jvm:7.0.12")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.retry:spring-retry")
 
+	implementation("org.redisson:redisson-spring-boot-starter:3.50.0")
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis/:/data
 
 networks:
   default:

--- a/src/main/kotlin/kr/hhplus/be/server/application/CouponWithLockService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/CouponWithLockService.kt
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.application
+
+import kr.hhplus.be.server.global.lock.DistributedLockHandler
+import kr.hhplus.be.server.global.lock.LockResource
+import kr.hhplus.be.server.presentation.request.CouponIssueRequest
+import kr.hhplus.be.server.presentation.response.IssuedCouponResponse
+import org.springframework.stereotype.Service
+
+@Service
+class CouponWithLockService(
+    private val couponService: CouponService,
+    private val distributedLockHandler: DistributedLockHandler
+) {
+
+    fun issueCoupon(request: CouponIssueRequest): IssuedCouponResponse {
+        return distributedLockHandler.executeWithLock(
+            listOf(LockResource.COUPON + request.couponId)
+        ) {
+            couponService.issueCoupon(request)
+        }
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/OrderWithLockService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/OrderWithLockService.kt
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.application
+
+import kr.hhplus.be.server.global.lock.DistributedLockHandler
+import kr.hhplus.be.server.global.lock.LockResource
+import kr.hhplus.be.server.presentation.request.OrderRequest
+import kr.hhplus.be.server.presentation.response.OrderResponse
+import org.springframework.stereotype.Service
+
+@Service
+class OrderWithLockService(
+    private val orderService: OrderService,
+    private val distributedLockHandler: DistributedLockHandler
+) {
+
+    fun order(request: OrderRequest): OrderResponse {
+        return distributedLockHandler.executeWithLock(
+            getLockKeysFromOrderRequest(request)
+        ) {
+            orderService.order(request)
+        }
+    }
+
+    private fun getLockKeysFromOrderRequest(request: OrderRequest): MutableList<String> {
+        val lockKeys = mutableListOf<String>()
+
+        lockKeys.add(LockResource.USER + request.userId)
+
+        request.userCouponId?.let {
+            lockKeys.add(LockResource.USER_COUPON + it)
+        }
+
+        request.orderItems
+            .sortedBy { it.productId }
+            .forEach { product ->
+                lockKeys.add(LockResource.PRODUCT + product.productId)
+            }
+        return lockKeys
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/application/ProductService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/ProductService.kt
@@ -1,18 +1,22 @@
 package kr.hhplus.be.server.application
 
+import kr.hhplus.be.server.domain.OrderItemStatus
 import kr.hhplus.be.server.infrastructure.OrderItemRepository
 import kr.hhplus.be.server.domain.Product
+import kr.hhplus.be.server.global.cache.CacheName
+import kr.hhplus.be.server.global.util.TimeProvider
 import kr.hhplus.be.server.infrastructure.ProductRepository
 import kr.hhplus.be.server.infrastructure.findByIdOrThrow
 import kr.hhplus.be.server.presentation.response.ProductResponse
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 class ProductService(
     private val productRepository: ProductRepository,
-    private val orderItemRepository: OrderItemRepository
+    private val orderItemRepository: OrderItemRepository,
+    private val timeProvider: TimeProvider
 ) {
     companion object {
         const val POPULAR_PRODUCT_LIMIT: Int = 5
@@ -27,14 +31,29 @@ class ProductService(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = [CacheName.POPULAR_PRODUCTS])
     fun getPopularProducts(): List<ProductResponse> {
 
-        val startDate = LocalDateTime.now().minusDays(POPULAR_PRODUCT_SCAN_DAY_RANGE)
-        val productIds = orderItemRepository.findTopDistinctPurchasedProductIdsByCreatedAtAfter(POPULAR_PRODUCT_LIMIT, startDate)
+        val productIds = getMostPurchasedProductIds()
 
         val sortedProducts = getSortedProducts(productIds)
 
         return sortedProducts.map { ProductResponse.from(it) }
+    }
+
+    private fun getMostPurchasedProductIds(): List<Long> {
+        val currentDate = timeProvider.getCurrentDate()
+        val rangeStartAt = currentDate.minusDays(POPULAR_PRODUCT_SCAN_DAY_RANGE).atStartOfDay()
+        val rangeEndAt = currentDate.atStartOfDay()
+
+        val productIds = orderItemRepository.findTopDistinctProductIdsByStatusAndCreatedAtRange(
+            POPULAR_PRODUCT_LIMIT,
+            OrderItemStatus.PURCHASE,
+            rangeStartAt,
+            rangeEndAt
+        )
+
+        return productIds
     }
 
     private fun getSortedProducts(productIds: List<Long>): List<Product> {

--- a/src/main/kotlin/kr/hhplus/be/server/global/cache/CacheName.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/cache/CacheName.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.global.cache
+
+object CacheName {
+    const val POPULAR_PRODUCTS = "popularProducts"
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/config/ApplicationConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/config/ApplicationConfig.kt
@@ -1,0 +1,9 @@
+package kr.hhplus.be.server.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class ApplicationConfig {
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/config/RedisCacheConfig.kt
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.global.config
+
+import kr.hhplus.be.server.global.cache.CacheName
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig(
+    @Value("\${spring.data.redis.host}") val redisHost: String,
+    @Value("\${spring.data.redis.port}") val redisPort: Int,
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        return LettuceConnectionFactory(redisHost, redisPort)
+    }
+
+    @Bean
+    fun redisCacheManager(redisConnectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .disableCachingNullValues()
+
+        val cacheConfigs: Map<String, RedisCacheConfiguration> = mapOf(
+            CacheName.POPULAR_PRODUCTS to RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(1))
+        )
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigs)
+            .build()
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/config/RedissonConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/config/RedissonConfig.kt
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.global.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(
+    @Value("\${spring.data.redis.host}") val redisHost: String,
+    @Value("\${spring.data.redis.port}") val redisPort: Int,
+) {
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        config.useSingleServer()
+            .setAddress("redis://$redisHost:$redisPort")
+
+        return Redisson.create(config)
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/exception/DistributedLockAcquisitionException.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/exception/DistributedLockAcquisitionException.kt
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.global.exception
+
+class DistributedLockAcquisitionException(keys: String) :
+    RuntimeException("Failed to acquire distributed lock for keys: $keys")

--- a/src/main/kotlin/kr/hhplus/be/server/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/exception/GlobalExceptionHandler.kt
@@ -23,6 +23,14 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         return handleExceptionInternal(ResponseStatus.INVALID_PARAMETER, e.message ?: "잘못된 파라미터입니다.")
     }
 
+    @ExceptionHandler(DistributedLockAcquisitionException::class)
+    fun handleDistributedLockAcquisitionException(e: DistributedLockAcquisitionException): ResponseEntity<Any> {
+        return handleExceptionInternal(
+            ResponseStatus.DISTRIBUTED_LOCK_ACQUISITION_FAILED,
+            e.message ?: ResponseStatus.DISTRIBUTED_LOCK_ACQUISITION_FAILED.message
+        )
+    }
+
     override fun handleMethodArgumentNotValid(
         ex: MethodArgumentNotValidException,
         headers: HttpHeaders,

--- a/src/main/kotlin/kr/hhplus/be/server/global/exception/ResponseStatus.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/exception/ResponseStatus.kt
@@ -27,6 +27,9 @@ enum class ResponseStatus(
     INVALID_COUPON(HttpStatus.BAD_REQUEST, 4002, "쿠폰이 유효하지 않습니다."),
     COUPON_EXPIRED(HttpStatus.BAD_REQUEST, 4003, "쿠폰이 만료되었습니다."),
     COUPON_OUT_OF_STOCK(HttpStatus.UNPROCESSABLE_ENTITY, 4004, "쿠폰이 모두 소진되었습니다."),
-    COUPON_ISSUE_FAILED(HttpStatus.CONFLICT, 4005, "쿠폰 발급에 실패했습니다.")
+    COUPON_ISSUE_FAILED(HttpStatus.CONFLICT, 4005, "쿠폰 발급에 실패했습니다."),
+
+    // Infra (5xxxx)
+    DISTRIBUTED_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, 50001, "분산 락 획득에 실패했습니다.")
 
 }

--- a/src/main/kotlin/kr/hhplus/be/server/global/lock/DistributedLockHandler.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/lock/DistributedLockHandler.kt
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.global.lock
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kr.hhplus.be.server.global.exception.DistributedLockAcquisitionException
+import org.redisson.RedissonMultiLock
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class DistributedLockHandler(
+    private val redissonClient: RedissonClient,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    fun <T> executeWithLock(
+        lockKeys: List<String>,
+        waitTime: Long = 10,
+        leaseTime: Long = 5,
+        unit: TimeUnit = TimeUnit.SECONDS,
+        action: () -> T
+    ): T {
+        val locks = lockKeys.map { redissonClient.getLock(it) }
+        val multiLock = RedissonMultiLock(*locks.toTypedArray())
+        return try {
+            val locked = multiLock.tryLock(waitTime, leaseTime, unit)
+            if (!locked) throw DistributedLockAcquisitionException(lockKeys.toString())
+
+            action()
+        } finally {
+            try {
+                multiLock.unlock()
+            } catch (e: IllegalMonitorStateException) {
+                logger.warn { "Lock is not locked: $lockKeys" }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/lock/LockResource.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/lock/LockResource.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.global.lock
+
+object LockResource {
+    const val USER = "lock:user:"
+    const val COUPON = "lock:coupon:"
+    const val USER_COUPON = "lock:userCoupon:"
+    const val PRODUCT = "lock:product:"
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/util/Scheduler.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/util/Scheduler.kt
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.global.util
+
+import kr.hhplus.be.server.global.cache.CacheName
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class Scheduler(
+    private val redisCacheManager: RedisCacheManager
+) {
+
+    @Scheduled(cron = "0 0 0 * * *")
+    fun clearPopularProductsCache() {
+        redisCacheManager.getCache(CacheName.POPULAR_PRODUCTS)?.clear()
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/util/TimeProvider.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/util/TimeProvider.kt
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.global.util
+
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class TimeProvider {
+    fun getCurrentDate(): LocalDate {
+        return LocalDate.now()
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/OrderItemRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/OrderItemRepository.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.infrastructure
 
 import kr.hhplus.be.server.domain.Order
 import kr.hhplus.be.server.domain.OrderItem
+import kr.hhplus.be.server.domain.OrderItemStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -14,14 +15,20 @@ interface OrderItemRepository : JpaRepository<OrderItem, Long> {
         """
         SELECT oi.productId
         FROM OrderItem oi 
-        WHERE oi.createdAt >= :startAt 
-        AND oi.status = kr.hhplus.be.server.domain.OrderItemStatus.PURCHASE 
+        WHERE oi.createdAt >= :startAt
+        AND oi.createdAt < :endAt
+        AND oi.status = :status 
         GROUP BY oi.productId
         ORDER BY SUM(oi.quantity) DESC
         LIMIT :limitNumber
     """
     )
-    fun findTopDistinctPurchasedProductIdsByCreatedAtAfter(limitNumber: Int, startAt: LocalDateTime): List<Long>
+    fun findTopDistinctProductIdsByStatusAndCreatedAtRange(
+        limitNumber: Int,
+        status: OrderItemStatus = OrderItemStatus.PURCHASE,
+        startAt: LocalDateTime,
+        endAt: LocalDateTime
+    ): List<Long>
 
     fun findByOrder(order: Order): List<OrderItem>
 

--- a/src/main/kotlin/kr/hhplus/be/server/presentation/CouponController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/presentation/CouponController.kt
@@ -1,6 +1,6 @@
 package kr.hhplus.be.server.presentation
 
-import kr.hhplus.be.server.application.CouponService
+import kr.hhplus.be.server.application.CouponWithLockService
 import kr.hhplus.be.server.presentation.docs.CouponApiDocs
 import kr.hhplus.be.server.presentation.request.CouponIssueRequest
 import kr.hhplus.be.server.presentation.response.IssuedCouponResponse
@@ -12,14 +12,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/coupons")
 class CouponController(
-    private val couponService: CouponService
+    private val couponWithLockService: CouponWithLockService
 ) : CouponApiDocs {
 
     @PostMapping("/issue")
     override fun issueCoupon(
         @RequestBody request: CouponIssueRequest
     ): IssuedCouponResponse {
-        return couponService.issueCoupon(request)
+        return couponWithLockService.issueCoupon(request)
     }
 
 }

--- a/src/main/kotlin/kr/hhplus/be/server/presentation/OrderController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/presentation/OrderController.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.presentation
 
 import jakarta.validation.Valid
 import kr.hhplus.be.server.application.OrderService
+import kr.hhplus.be.server.application.OrderWithLockService
 import kr.hhplus.be.server.presentation.docs.OrderApiDocs
 import kr.hhplus.be.server.presentation.request.OrderRequest
 import kr.hhplus.be.server.presentation.response.OrderResponse
@@ -13,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/orders")
 class OrderController(
-    private val orderService: OrderService
+    private val orderWithLockService: OrderWithLockService
 ) : OrderApiDocs {
 
     @PostMapping
     override fun order(@Valid @RequestBody request: OrderRequest): OrderResponse {
-        return orderService.order(request);
+        return orderWithLockService.order(request);
     }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/presentation/response/ProductResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/presentation/response/ProductResponse.kt
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.presentation.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import kr.hhplus.be.server.domain.Product
+import java.io.Serializable
 
 @Schema(description = "상품 정보")
 data class ProductResponse(
@@ -16,7 +17,7 @@ data class ProductResponse(
 
     @Schema(description = "재고 수량")
     val stock: Int,
-) {
+) : Serializable {
     companion object {
         fun from(product: Product): ProductResponse {
             return ProductResponse(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,7 @@ spring:
     init:
       mode: always
       schema-locations: classpath:database/schema.sql
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.kt
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.kt
@@ -2,29 +2,36 @@ package kr.hhplus.be.server
 
 import jakarta.annotation.PreDestroy
 import org.springframework.context.annotation.Configuration
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @Configuration
 class TestcontainersConfiguration {
+
     @PreDestroy
     fun preDestroy() {
         if (mySqlContainer.isRunning) mySqlContainer.stop()
+        if (redisContainer.isRunning) redisContainer.stop()
     }
 
     companion object {
-        val mySqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0"))
-            .withDatabaseName("hhplus")
-            .withUsername("test")
-            .withPassword("test")
+        private val mySqlContainer: MySQLContainer<*> = MySQLContainer(DockerImageName.parse("mysql:8.0"))
             .apply {
                 start()
             }
+
+        private val redisContainer: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:7.0"))
+            .withExposedPorts(6379)
+            .apply { start() }
+
 
         init {
             System.setProperty("spring.datasource.url", mySqlContainer.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC")
             System.setProperty("spring.datasource.username", mySqlContainer.username)
             System.setProperty("spring.datasource.password", mySqlContainer.password)
+            System.setProperty("spring.data.redis.host", redisContainer.host)
+            System.setProperty("spring.data.redis.port", redisContainer.firstMappedPort.toString())
         }
     }
 }

--- a/src/test/java/kr/hhplus/be/server/application/CouponWithLockServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/application/CouponWithLockServiceIntegrationTest.kt
@@ -1,0 +1,95 @@
+package kr.hhplus.be.server.application
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kr.hhplus.be.server.domain.Coupon
+import kr.hhplus.be.server.domain.DiscountType
+import kr.hhplus.be.server.domain.User
+import kr.hhplus.be.server.global.exception.BusinessException
+import kr.hhplus.be.server.global.exception.ResponseStatus
+import kr.hhplus.be.server.infrastructure.CouponRepository
+import kr.hhplus.be.server.infrastructure.UserCouponRepository
+import kr.hhplus.be.server.infrastructure.UserRepository
+import kr.hhplus.be.server.presentation.request.CouponIssueRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.*
+import java.util.concurrent.CountDownLatch
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CouponWithLockServiceIntegrationTest @Autowired constructor(
+    private val couponWithLockService: CouponWithLockService,
+    private val couponRepository: CouponRepository,
+    private val userCouponRepository: UserCouponRepository,
+    private val userRepository: UserRepository
+) {
+
+    @BeforeEach
+    fun setUp() {
+        userCouponRepository.deleteAll()
+        couponRepository.deleteAll()
+        userRepository.deleteAll()
+    }
+
+    @Test
+    fun `issueCoupon - (동시성 테스트) 여러 사용자가 동시에 쿠폰을 발급받을 때 발급 가능 수량 만큼만 발급되어야 한다`() {
+        // Given
+        val users = listOf(
+            userRepository.save(User(name = "User1", point = 1000L)),
+            userRepository.save(User(name = "User2", point = 1000L)),
+            userRepository.save(User(name = "User3", point = 1000L)),
+            userRepository.save(User(name = "User4", point = 1000L))
+        )
+
+        val couponIssueLimit = 2L
+
+        val coupon = Coupon(
+            name = "Test Coupon",
+            discountAmount = 100L,
+            discountType = DiscountType.PRICE,
+            issueLimit = couponIssueLimit,
+            issuedRemain = couponIssueLimit,
+            issuable = true
+        )
+        val savedCoupon = couponRepository.save(coupon)
+        val latch = CountDownLatch(users.size)
+
+        // When
+        val exceptions = Collections.synchronizedCollection(mutableListOf<Exception>())
+
+        runBlocking {
+            users.forEach { user ->
+                launch(Dispatchers.IO) {
+                    try {
+                        couponWithLockService.issueCoupon(CouponIssueRequest(userId = user.id, couponId = savedCoupon.id))
+                    } catch (e: BusinessException) {
+                        if (e.status == ResponseStatus.COUPON_OUT_OF_STOCK) {
+                            exceptions.add(e)
+                        }
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+        }
+        latch.await()
+
+        // Then
+        val userCoupons = users.flatMap { user ->
+            userCouponRepository.findByUserId(user.id)
+        }
+        assertThat(userCoupons).hasSize(couponIssueLimit.toInt())
+
+        assertThat(exceptions.size).isEqualTo(users.size - couponIssueLimit.toInt())
+
+        couponRepository.findById(savedCoupon.id).ifPresent {
+            assertThat(it.issuedRemain).isEqualTo(0L)
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/OrderWithLockServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/application/OrderWithLockServiceIntegrationTest.kt
@@ -1,0 +1,147 @@
+package kr.hhplus.be.server.application
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kr.hhplus.be.server.domain.*
+import kr.hhplus.be.server.global.exception.BusinessException
+import kr.hhplus.be.server.global.exception.ResponseStatus
+import kr.hhplus.be.server.infrastructure.*
+import kr.hhplus.be.server.presentation.request.OrderItemRequest
+import kr.hhplus.be.server.presentation.request.OrderRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.*
+import java.util.concurrent.CountDownLatch
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderWithLockServiceIntegrationTest @Autowired constructor(
+    private val orderWithLockService: OrderWithLockService,
+    private val userRepository: UserRepository,
+    private val userPointHistoryRepository: UserPointHistoryRepository,
+    private val productRepository: ProductRepository,
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val couponRepository: CouponRepository,
+    private val userCouponRepository: UserCouponRepository
+) {
+
+    @BeforeEach
+    fun setUp() {
+        orderItemRepository.deleteAll()
+        orderRepository.deleteAll()
+        userPointHistoryRepository.deleteAll()
+        userCouponRepository.deleteAll()
+        couponRepository.deleteAll()
+        productRepository.deleteAll()
+        userRepository.deleteAll()
+    }
+
+    @Test
+    fun `order - (동시성 테스트) 여러 사용자가 동시에 주문을 하는 경우 재고 수량만큼 주문이 성공해야 한다`() {
+        // Given
+        val users = listOf(
+            userRepository.save(User(name = "User1", point = 1000L)),
+            userRepository.save(User(name = "User2", point = 1000L)),
+            userRepository.save(User(name = "User3", point = 1000L)),
+            userRepository.save(User(name = "User4", point = 1000L)),
+            userRepository.save(User(name = "User5", point = 1000L)),
+            userRepository.save(User(name = "User6", point = 1000L)),
+            userRepository.save(User(name = "User7", point = 1000L)),
+            userRepository.save(User(name = "User8", point = 1000L)),
+            userRepository.save(User(name = "User9", point = 1000L)),
+            userRepository.save(User(name = "User10", point = 1000L))
+        )
+
+        val stock = 2
+
+        val product = productRepository.save(Product(name = "Product", price = 100L, stock = stock))
+
+        val latch = CountDownLatch(users.size)
+
+        // When
+        val exceptions = Collections.synchronizedCollection(mutableListOf<Exception>())
+
+        runBlocking {
+            users.forEach { user ->
+                launch {
+                    try {
+                        val request = OrderRequest(
+                            userId = user.id,
+                            orderItems = listOf(OrderItemRequest(productId = product.id, quantity = 1))
+                        )
+
+                        orderWithLockService.order(request)
+                    } catch (e: BusinessException) {
+                        if (e.status == ResponseStatus.PRODUCT_OUT_OF_STOCK) {
+                            exceptions.add(e)
+                        }
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+        }
+        latch.await()
+
+        // Then
+        val productResult = productRepository.findByIdOrThrow(product.id)
+        assertThat(productResult.stock).isEqualTo(0)
+
+        assertThat(exceptions).hasSize(users.size - stock)
+    }
+
+    @Test
+    fun `order - (동시성 테스트) 한명의 사용자가 동시에 여러 번 구매를 시도할 때 포인트 여유가 되는만큼 주문이 성공해야 한다`() {
+        // Given
+        val userPoint = 300L
+        val user = userRepository.save(User(name = "User", point = userPoint))
+
+        val stock = 10
+        val productPrice = 100L
+        val product = productRepository.save(Product(name = "Product", price = productPrice, stock = stock))
+
+        val orderCount = 10
+        val latch = CountDownLatch(orderCount)
+
+        val request = OrderRequest(
+            userId = user.id,
+            orderItems = listOf(OrderItemRequest(productId = product.id, quantity = 1))
+        )
+
+        // When
+        val exceptions = Collections.synchronizedCollection(mutableListOf<Exception>())
+
+        runBlocking {
+            repeat(orderCount) {
+                launch {
+                    try {
+                        orderWithLockService.order(request)
+                    } catch (e: BusinessException) {
+                        if (e.status == ResponseStatus.POINT_NOT_ENOUGH) {
+                            exceptions.add(e)
+                        }
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+        }
+        latch.await()
+
+        // Then
+        val productResult = productRepository.findByIdOrThrow(product.id)
+        assertThat(productResult.stock).isEqualTo(stock - (userPoint / productPrice).toInt())
+
+        val orders = orderRepository.findByUserId(user.id)
+        assertThat(orders).hasSize((userPoint / productPrice).toInt())
+
+        assertThat(exceptions).hasSize(
+            orderCount - (userPoint / productPrice).toInt()
+        )
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/ProductServiceIntegrationTest.kt
+++ b/src/test/java/kr/hhplus/be/server/application/ProductServiceIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -75,14 +76,16 @@ class ProductServiceIntegrationTest @Autowired constructor(
 
     @Test
     fun `getPopularProducts - 인기 상품 상위 5개를 순서대로 조회`() {
+        val now = LocalDateTime.now()
+
         // Given
         orderItemRepository.saveAll(
             listOf(
-                OrderItem(productId = product1.id, quantity = 5),
-                OrderItem(productId = product2.id, quantity = 3),
-                OrderItem(productId = product3.id, quantity = 2),
-                OrderItem(productId = product4.id, quantity = 1),
-                OrderItem(productId = product5.id, quantity = 4)
+                OrderItem(productId = product1.id, quantity = 5, createdAt = now.minusDays(1)),
+                OrderItem(productId = product2.id, quantity = 3, createdAt = now.minusDays(2)),
+                OrderItem(productId = product3.id, quantity = 2, createdAt = now.minusDays(1)),
+                OrderItem(productId = product4.id, quantity = 1, createdAt = now.minusDays(2)),
+                OrderItem(productId = product5.id, quantity = 4, createdAt = now.minusDays(3))
             )
         )
 


### PR DESCRIPTION
### **핵심 체크리스트** :white_check_mark:

#### :one: 분산락 적용 (3개)
- [x] 적절한 곳에 분산락이 사용되었는가?
- [x] 트랜젝션 순서와 락순서가 보장되었는가?

#### :two: 통합 테스트 (2개)
- [x] infrastructure 레이어를 포함하는 통합 테스트가 작성되었는가?
- [x] 핵심 기능에 대한 흐름이 테스트에서 검증되었는가?
- [x] 동시성을 검증할 수 있는 테스트코드로 작성 되었는가?
- [x] Test Container 가 적용 되었는가?

#### :three: Cache 적용 (3개)
- [x] 적절하게 Key 적용이 되었는가?

---
#### STEP11
- [x] Redis 분산락 적용
- [x] Test Container 구성
- [x] 기능별 통합 테스트

#### STEP12

[Redis 캐싱 적용 전 후 비교 분석 보고서](https://github.com/hanwix2/e-commerce-service/wiki/Redis-%EC%BA%90%EC%8B%B1-%EC%A0%81%EC%9A%A9-%EC%A0%84-%ED%9B%84-%EB%B9%84%EA%B5%90-%EB%B6%84%EC%84%9D-%EB%B3%B4%EA%B3%A0%EC%84%9C)  


- [x] 캐시 필요한 부분 분석
- [x] redis 기반의 캐시 적용
- [x] 성능 개선 등을 포함한 보고서 제출

--- 
### Review Point
- '인기 상품 조회' 의 결과 데이터가 매번 공통된 값이 아니어서 캐싱을 적용하는데 애매한 부분이 있어 비즈니스적 요구사항 및 내부 로직을 수정하였습니다.
    - As is: 
        - 현재 시점(초단위)으로 부터 3일 간의 인기 상품 조회
        - 현재가 10일 09시라면, 7일 09시부터 현재 시점까지의 가장 많이 팔린 상품
    - To be: 
        - 어제까지의 3일간의 인기 상품 조회
        - 오늘이 10일이라면, 7~9일간의 가장 많이 팔린 상품

--- 
### **간단 회고** (3줄 이내)
- **잘한 점**: 성능 테스트를 해보았다.
- **어려운 점**:
    - AOP 로 분산락을 도입하려다 생각보다 코드가 깔끔하지 않아서 Handler 빈으로 적용하였다. 
        - 기존 Service 빈을 주입한 Lock 사용 Service 를 새로 생성하였는데 좋은 구조인지 의문이 있다.
    - 멀티 락을 걸어야 할 때 Lock key 를 생성하는 로직이 템플릿화 하기 어려웠다.
- **다음 시도**:
    - 분산 락 관련 시간 설정에 대해 깊게 알아봐야 할 것 같다.