### PR TITLE
[STEP 15 / STEP 16] 신정한 - e-commerce

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEvent.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEvent.kt
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.application.event
+
+import kr.hhplus.be.server.presentation.response.OrderResponse
+
+class OrderedEvent(
+    val userId: Long,
+    val totalPrice: Long,
+    val discountAmount: Long,
+    val paidAmount: Long,
+    val items: List<OrderedEventItem>
+) {
+    companion object {
+        fun from(orderResponse: OrderResponse): OrderedEvent {
+            return OrderedEvent(
+                userId = orderResponse.userId,
+                totalPrice = orderResponse.totalPrice,
+                discountAmount = orderResponse.discountAmount,
+                paidAmount = orderResponse.paidAmount,
+                items = orderResponse.items.map {
+                    OrderedEventItem(
+                        productName = it.productName,
+                        quantity = it.quantity,
+                        price = it.price
+                    )
+                }
+            )
+        }
+    }
+}
+
+class OrderedEventItem(
+    val productName: String,
+    val quantity: Int,
+    val price: Long
+)

--- a/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
@@ -14,19 +14,23 @@ class OrderedEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleEvent(event: OrderedEvent) {
-        logger.info {
-            """[데이터 플랫폼 주문 정보 전송]
-            | - userId: ${event.userId}
-            | - 총 금액: ${event.totalPrice}
-            | - 할인 금액: ${event.discountAmount}
-            | - 결제 금액: ${event.paidAmount}
-            | - 상품:
-            |${
-                event.items.joinToString("\n") { item ->
-                    """    - 상품명: ${item.productName}, 수량: ${item.quantity}, 가격: ${item.price}"""
+        try {
+            logger.info {
+                """[데이터 플랫폼 주문 정보 전송]
+                | - userId: ${event.userId}
+                | - 총 금액: ${event.totalPrice}
+                | - 할인 금액: ${event.discountAmount}
+                | - 결제 금액: ${event.paidAmount}
+                | - 상품:
+                |${
+                    event.items.joinToString("\n") { item ->
+                        """    - 상품명: ${item.productName}, 수량: ${item.quantity}, 가격: ${item.price}"""
+                    }
                 }
-            }
         """.trimMargin()
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "OrderedEvent 처리 중 오류 발생" }
         }
 
     }

--- a/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.application.event
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -10,6 +11,7 @@ class OrderedEventListener {
 
     private val logger = KotlinLogging.logger {}
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleEvent(event: OrderedEvent) {
         logger.info {

--- a/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/event/OrderedEventListener.kt
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.application.event
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class OrderedEventListener {
+
+    private val logger = KotlinLogging.logger {}
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleEvent(event: OrderedEvent) {
+        logger.info {
+            """[데이터 플랫폼 주문 정보 전송]
+            | - userId: ${event.userId}
+            | - 총 금액: ${event.totalPrice}
+            | - 할인 금액: ${event.discountAmount}
+            | - 결제 금액: ${event.paidAmount}
+            | - 상품:
+            |${
+                event.items.joinToString("\n") { item ->
+                    """    - 상품명: ${item.productName}, 수량: ${item.quantity}, 가격: ${item.price}"""
+                }
+            }
+        """.trimMargin()
+        }
+
+    }
+
+}

--- a/src/main/kotlin/kr/hhplus/be/server/global/config/ApplicationConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/global/config/ApplicationConfig.kt
@@ -1,9 +1,11 @@
 package kr.hhplus.be.server.global.config
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
 @EnableScheduling
+@EnableAsync
 class ApplicationConfig {
 }


### PR DESCRIPTION
### STEP 15 Application Event
commit: [Feature: 이벤트를 활용한 가상 데이터 플랫폼에 주문 정보 전송 로직 추가](https://github.com/hanwix2/e-commerce-service/pull/11/commits/4fe186248bbc9fca7fa32a168831a4739fff032f)
- [x] 주문/예약 정보를 원 트랜잭션이 종료된 이후에 전송
- [x] 주문/예약 정보를 전달하는 부가 로직에 대한 관심사를 메인 서비스에서 분리

### STEP 16 Transaction Diagnosis
설계 문서: [분산 환경에서의 트랜잭션 처리방안](https://github.com/hanwix2/e-commerce-service/wiki/%EB%B6%84%EC%82%B0-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C%EC%9D%98-%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98-%EC%B2%98%EB%A6%AC%EB%B0%A9%EC%95%88)
- [x] 도메인별로 트랜잭션이 분리되었을 때 발생 가능한 문제 파악
- [x] 트랜잭션이 분리되더라도 데이터 일관성을 보장할 수 있는 분산 트랜잭션 설계

### 리뷰 포인트
- 주문/결제 프로세스에서 Event 를 발생시켜 트랜잭션이 Commit 되었을 때 데이터 플랫폼으로 주문 데이터를 전달하는 로직을 추가하였습니다.
- '데이터 플랫폼으로 주문 데이터를 전달' 은 실제 API call 없이 로그를 남김는 것으로 대체하였습니다.
- Step 16 Transaction Diagnosis 의 설계 문서는 Wiki 에 작성하였습니다. (링크 첨부했습니다.)

### **간단 회고** (3줄 이내)
- **잘한 점**: 모호하게만 알고 있던 분산 환경에서의 트랜잭션 처리 방식을 명확히 하였다.
- **어려운 점**: 현재 구현한 것을 도메인별 application 을 분리하는 작업이 생각보다 너무 커서 시도하지 못했다. 
- **다음 시도**: Outbox 패턴을 아직 적용하진 않았는데 다음 주제에서 매끄럽게 적용할 수 있는 방식을 더 알아봐야 할 것 같다.